### PR TITLE
ci: include update paths

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -7,6 +7,8 @@ on:
       - dev
     paths:
       - '**/*.ipynb'
+      - 'environment.yml'
+      - 'run.py'
 
 jobs:
   build:


### PR DESCRIPTION
If we update the environment file or the run file, we need to run the action. Previously it was only looking at notebooks. 